### PR TITLE
don't merge - raise maximports, dump maxtc

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -33,7 +33,7 @@ my %module_build_args = (
     protocol       => 'https',
     host           => 'github.com',
     location       => '/netdisco/upstream-sources/blob/master/net-snmp/',
-    exact_filename => 'net-snmp-5.9.0.tar.gz?raw=true',
+    exact_filename => 'net-snmp-5.9.tar.gz?raw=true',
   },
   alien_stage_install => 0,
   build_requires      => {

--- a/Build.PL
+++ b/Build.PL
@@ -33,7 +33,7 @@ my %module_build_args = (
     protocol       => 'https',
     host           => 'github.com',
     location       => '/netdisco/upstream-sources/blob/master/net-snmp/',
-    exact_filename => 'net-snmp-5.7.3.tar.gz?raw=true',
+    exact_filename => 'net-snmp-5.9.0.tar.gz?raw=true',
   },
   alien_stage_install => 0,
   build_requires      => {

--- a/Build.PL
+++ b/Build.PL
@@ -33,7 +33,7 @@ my %module_build_args = (
     protocol       => 'https',
     host           => 'github.com',
     location       => '/netdisco/upstream-sources/blob/master/net-snmp/',
-    exact_filename => 'net-snmp-5.9.tar.gz?raw=true',
+    exact_filename => 'net-snmp-5.8.tar.gz?raw=true',
   },
   alien_stage_install => 0,
   build_requires      => {

--- a/META.json
+++ b/META.json
@@ -60,6 +60,6 @@
          "http://opensource.org/licenses/BSD-3-Clause"
       ]
    },
-   "version" : "1.001000",
+   "version" : "1.002000",
    "x_serialization_backend" : "JSON::PP version 2.97001"
 }

--- a/META.json
+++ b/META.json
@@ -51,7 +51,7 @@
    "provides" : {
       "Alien::SNMP::MAXTC" : {
          "file" : "lib/Alien/SNMP/MAXTC.pm",
-         "version" : "1.001000"
+         "version" : "1.002000"
       }
    },
    "release_status" : "stable",

--- a/META.json
+++ b/META.json
@@ -51,7 +51,7 @@
    "provides" : {
       "Alien::SNMP::MAXTC" : {
          "file" : "lib/Alien/SNMP/MAXTC.pm",
-         "version" : "1.002000"
+         "version" : "1.003000"
       }
    },
    "release_status" : "stable",
@@ -60,6 +60,6 @@
          "http://opensource.org/licenses/BSD-3-Clause"
       ]
    },
-   "version" : "1.002000",
+   "version" : "1.003000",
    "x_serialization_backend" : "JSON::PP version 2.97001"
 }

--- a/META.yml
+++ b/META.yml
@@ -27,7 +27,7 @@ name: Alien-SNMP-MAXTC
 provides:
   Alien::SNMP::MAXTC:
     file: lib/Alien/SNMP/MAXTC.pm
-    version: '1.001000'
+    version: '1.002000'
 requires:
   Alien::Base: '0.020'
   File::ShareDir: '1.03'

--- a/META.yml
+++ b/META.yml
@@ -35,5 +35,5 @@ requires:
   perl: '5.010001'
 resources:
   license: http://opensource.org/licenses/BSD-3-Clause
-version: '1.001000'
+version: '1.002000'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/META.yml
+++ b/META.yml
@@ -27,7 +27,7 @@ name: Alien-SNMP-MAXTC
 provides:
   Alien::SNMP::MAXTC:
     file: lib/Alien/SNMP/MAXTC.pm
-    version: '1.002000'
+    version: '1.003000'
 requires:
   Alien::Base: '0.020'
   File::ShareDir: '1.03'
@@ -35,5 +35,5 @@ requires:
   perl: '5.010001'
 resources:
   license: http://opensource.org/licenses/BSD-3-Clause
-version: '1.002000'
+version: '1.003000'
 x_serialization_backend: 'CPAN::Meta::YAML version 0.018'

--- a/inc/My/AlienPatch.pm
+++ b/inc/My/AlienPatch.pm
@@ -15,7 +15,7 @@ sub main::alien_patch {
     }
   }
 
-  my $maxtc = q{#define MAX_IMPORTS 256};
+  my $maxtc = q{#define MAX_IMPORTS 512};
   tie my @parse, 'Tie::File', 'snmplib/parse.c'
     or die "can't open parse.c: $!";
   for (@parse) {

--- a/inc/My/AlienPatch.pm
+++ b/inc/My/AlienPatch.pm
@@ -15,11 +15,11 @@ sub main::alien_patch {
     }
   }
 
-  my $maxtc = q{#define MAXTC 16384};
+  my $maxtc = q{#define MAX_IMPORTS 256};
   tie my @parse, 'Tie::File', 'snmplib/parse.c'
     or die "can't open parse.c: $!";
   for (@parse) {
-    if (m/#define\s+MAXTC\s+/) {
+    if (m/#define\s+MAX_IMPORTS\s+/) {
       $_ = $maxtc;
       last;
     }

--- a/inc/My/AlienPatch.pm
+++ b/inc/My/AlienPatch.pm
@@ -15,12 +15,12 @@ sub main::alien_patch {
     }
   }
 
-  my $maxtc = q{#define MAX_IMPORTS 512};
+  my $max_imports = q{#define MAX_IMPORTS 512};
   tie my @parse, 'Tie::File', 'snmplib/parse.c'
     or die "can't open parse.c: $!";
   for (@parse) {
     if (m/#define\s+MAX_IMPORTS\s+/) {
-      $_ = $maxtc;
+      $_ = $max_imports;
       last;
     }
   }

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -11,6 +11,6 @@ if ($^O eq 'MSWin32') {
 }
 
 sub alien_check_installed_version { return }
-sub alien_check_built_version { return '5.7.3' }
+sub alien_check_built_version { return '5.9.0' }
 
 1;

--- a/inc/My/ModuleBuild.pm
+++ b/inc/My/ModuleBuild.pm
@@ -11,6 +11,6 @@ if ($^O eq 'MSWin32') {
 }
 
 sub alien_check_installed_version { return }
-sub alien_check_built_version { return '5.9.0' }
+sub alien_check_built_version { return '5.8' }
 
 1;

--- a/lib/Alien/SNMP/MAXTC.pm
+++ b/lib/Alien/SNMP/MAXTC.pm
@@ -5,7 +5,7 @@ use warnings;
 use 5.010001;
 use parent qw(Alien::Base);
 
-our $VERSION = '1.002000';
+our $VERSION = '1.003000';
 
 1;
 
@@ -21,7 +21,7 @@ Alien::SNMP::MAXTC - Alien package for the Net-SNMP library
 
 =head1 VERSION
 
-Version 1.000001
+Version 1.003000
 
 =cut
 

--- a/lib/Alien/SNMP/MAXTC.pm
+++ b/lib/Alien/SNMP/MAXTC.pm
@@ -5,7 +5,7 @@ use warnings;
 use 5.010001;
 use parent qw(Alien::Base);
 
-our $VERSION = '1.001000';
+our $VERSION = '1.002000';
 
 1;
 

--- a/lib/Alien/SNMP/MAXTC.pm
+++ b/lib/Alien/SNMP/MAXTC.pm
@@ -28,10 +28,10 @@ Version 1.003000
 =head1 SYNOPSIS
 
  use Alien::SNMP::MAXTC;
- # then it's just like SNMP.pm
+ # then it's just like SNMP.pm
  
  say Alien::SNMP::MAXTC->bin_dir;
- # where the net-snmp apps (snmptranslate, etc) live
+ # where the net-snmp apps (snmptranslate, etc) live
 
 =head1 DESCRIPTION
 

--- a/lib/Alien/SNMP/MAXTC.pm
+++ b/lib/Alien/SNMP/MAXTC.pm
@@ -45,7 +45,7 @@ The library is built with the following options:
 
 =over
 
-=item MAXTC set to 16k
+=item MAX_IMPORTS set to 512
 
 =item C<--disable-agent>
 


### PR DESCRIPTION
**please do not merge**

i ran into an issue with ciscoucs mibs couldn't be parsed due to maximports being to small. this mangles alien::snmp::maxtc to raise maximports instead.

it's more of a placeholder/reminder that we still need something like a::s::maxtc but then for maximports. i'll try & get the work done.

**please do no merge**